### PR TITLE
Support version resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ $ npm install dynamo2es-lambda
 - **[idField]** - { String | String[] } - field(s) to be used as an Elasticsearch id; if multiple fields are provided, values are concatenated using `separator`; can't be used together with `idResolver` [defaults to document's key field(s)]
 - **[idResolver]** - { Function(record, old) } - optional function to format an Elasticsearch id; can't be used together with `idField`
 - **[versionField]** - { String } - field to be used as an [external version for Elasticsearch document][elasticsearch-versioning-url] [by default no version check is performed]
+- **[versionResolver]** - { Function(record, old) } - optional function to resolve a value to be used as an [external version for Elasticsearch document][elasticsearch-versioning-url]
 - **[parentField]** - { String } - field to be used as a [parent id][elasticsearch-parent-child-url] [no parent by default]
 - **[pickFields]** - { String | String[] } - by default, the whole document is sent to Elasticsearch for indexing; if this option is provided, only field(s) specified would be sent
 - **[separator]** - { String } - separator that is used to concatenate fields [defaults to `'.'`]

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -70,9 +70,11 @@ module.exports = function(options) {
                 actionDescriptionObj.parent = utils.getField(parsedRecord, options.parentField);
               }
 
-              if (options.versionField) {
-                const version = utils.getField(parsedRecord, options.versionField);
-                utils.validate(version, schemas.VERSION.label(options.versionField));
+              if (options.versionResolver || options.versionField) {
+                const version = options.versionResolver
+                  ? options.versionResolver(doc, parsedRecord.OldImage)
+                  : utils.getField(parsedRecord, options.versionField);
+                utils.validate(version, schemas.VERSION.label(options.versionField || 'resolved version'));
                 actionDescriptionObj.version = version;
                 actionDescriptionObj.versionType = 'external';
               }

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -30,10 +30,12 @@ const HANDLER_OPTIONS = joi
     parentField: FIELD,
     pickFields: [FIELD, joi.array().min(1).items(FIELD)],
     versionField: FIELD,
+    versionResolver: joi.func(),
     retryOptions: joi.object()
   })
   .without('elasticsearch', 'es')
   .oxor('idField', 'idResolver')
+  .oxor('versionField', 'versionResolver')
   .xor('index', 'indexField')
   .xor('type', 'typeField')
   .without('index', 'indexPrefix')


### PR DESCRIPTION
Add a `versionResolver` option to accommodate use cases such as creating a version from a timestamp field.